### PR TITLE
Missing attribute family

### DIFF
--- a/app/code/community/Pimgento/Attribute/Model/Import.php
+++ b/app/code/community/Pimgento/Attribute/Model/Import.php
@@ -306,8 +306,9 @@ class Pimgento_Attribute_Model_Import extends Pimgento_Core_Model_Import_Abstrac
      */
     protected function _updateFamily($data)
     {
-        if (!isset($data['families'])) {
-            $data['families'] = "Marshalls";
+        if (empty($data['families'])) {
+            $defaultAttributeSets = Mage::getStoreConfig('pimdata/attribute/families');
+            $data['families'] = $defaultAttributeSets;
         }
 
         /* @var $model Mage_Catalog_Model_Resource_Eav_Attribute */

--- a/app/code/community/Pimgento/Attribute/etc/system.xml
+++ b/app/code/community/Pimgento/Attribute/etc/system.xml
@@ -92,6 +92,15 @@
                             <show_in_website>0</show_in_website>
                             <show_in_store>0</show_in_store>
                         </types>
+                        <families>
+                            <label>Default Attribute Set</label>
+                            <frontend_type>text</frontend_type>
+                            <comment>Enter the attribute sets to allocate attributes with no family, comma separated</comment>
+                            <sort_order>8</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>0</show_in_website>
+                            <show_in_store>0</show_in_store>
+                        </families>
                     </fields>
                 </attribute>
             </groups>


### PR DESCRIPTION
If an attribute has not been allocated to a family then the SQL blows up.  This change fixes that issue by allocating the attribute to the supplied family
